### PR TITLE
customer/itemsで商品の画像を取得するときに一括取得してSQLの実行回数を減少

### DIFF
--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -27,7 +27,7 @@ class Public::ItemsController < ApplicationController
       items = Item.all
     end
 
-    return items.where(is_active: true)
+    return items.where(is_active: true).with_attached_image
   end
 
   # 販売中の商品を１つ取得し、インスタンス変数(@item)に格納する


### PR DESCRIPTION
参考記事
https://shuttodev.hatenablog.com/entry/2019/09/10/012916
https://qiita.com/ozin/items/f4aea5b244a6aa03caee