### PR TITLE
admin/ordersで注文履歴一覧に関する修正

### DIFF
--- a/app/controllers/admin/homes_controller.rb
+++ b/app/controllers/admin/homes_controller.rb
@@ -1,4 +1,5 @@
 class Admin::HomesController < ApplicationController
+  before_action :authenticate_admin! # 管理者としてログインしなけらば使用できない
   def top
     @orders = Order.includes(:customer)
     @orders = @orders.page(params[:page])

--- a/app/controllers/admin/homes_controller.rb
+++ b/app/controllers/admin/homes_controller.rb
@@ -1,7 +1,22 @@
 class Admin::HomesController < ApplicationController
   before_action :authenticate_admin! # 管理者としてログインしなけらば使用できない
+  before_action :define_orders, only: [:top]
+
   def top
-    @orders = Order.includes(:customer)
+  end
+
+  private
+
+  # urlにcustomer_idというパラメータがある場合は顧客ごとの注文履歴を表示
+  # それ以外は注文を10件までを取得する
+  def define_orders
+    if params[:customer_id]
+      customer = Customer.find(params[:customer_id])
+      @orders = customer.orders
+    else
+      @orders = Order.includes(:customer)
+    end
+
     @orders = @orders.page(params[:page])
   end
 end

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -47,8 +47,7 @@
         <dt class="col-3"></dt>
         <dd class="col-8">
           <%= link_to "編集する", edit_admin_customer_path(@customer.id), class: "btn btn-success py-2 px-4 mr-5" %>
-          <%# 注文履歴一覧のリンクは未実装 %>
-          <%= link_to "注文履歴一覧を見る", "#", class: "btn btn-primary px-4 py-2"%>
+          <%= link_to "注文履歴一覧を見る", admin_root_path(customer_id: @customer.id), class: "btn btn-primary px-4 py-2"%>
         </dd>
       </div>
     </dl>


### PR DESCRIPTION
admin/ordersで注文履歴一覧を顧客ごとに表示できるように機能を追加
管理者としてログイン済みでないと機能が使えないように修正
